### PR TITLE
Switch to pyviz main channel for pyctdev on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
         - pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev
         - export PATH="$HOME/miniconda/bin:$PATH" && hash -r
         - conda config --set always_yes True
-        - conda install -c pyviz/label/dev pyctdev && doit ecosystem_setup
+        - conda install -c pyviz pyctdev && doit ecosystem_setup
       install:
         - doit env_create $CHANS_DEV --python=$PYENV_VERSION
         - source activate test-environment


### PR DESCRIPTION
Means hvplot will keep using the same version of pyctdev that it's using currently, rather than some potentially disruptive dev releases before the next main release.