### PR TITLE
Add crs from ds if possible

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -145,7 +145,7 @@ class HoloViewsConverter(param.Parameterized):
         self.group_label = group_label
         self.dynamic = dynamic
         self.geo = geo or crs or global_extent or projection
-        self.crs = process_crs(crs) if self.geo else None
+        self.crs = self._process_crs(data, crs) if self.geo else None
         self.row = row
         self.col = col
 
@@ -237,6 +237,21 @@ class HoloViewsConverter(param.Parameterized):
                         groupby=self.groupby)
             self.warning('Plotting {kind} plot with parameters x: {x}, '
                          'y: {y}, by: {by}, groupby: {groupby}'.format(**kwds))
+
+
+    def _process_crs(self, data, crs):
+        """Given crs as proj4 string, data.attr, or cartopy.crs return cartopy.crs
+        """
+        # get the proj string: either the value of data.attrs[crs] or crs itself
+        _crs = getattr(data, 'attrs', {}).get(crs or 'crs', crs)
+        try:
+            return process_crs(_crs)
+        except ValueError:
+            # only raise error if crs was specified in kwargs
+            if crs:
+                raise ValueError(
+                    "'{}' must be either a valid crs or an reference to "
+                    "a `data.attr` containing a valid crs.".format(crs))
 
 
     def _process_data(self, kind, data, x, y, by, groupby, row, col,

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -1,0 +1,48 @@
+from unittest import TestCase, SkipTest
+
+
+class TestGeo(TestCase):
+    def setUp(self):
+        try:
+            import xarray as xr
+            import rasterio  # noqa
+            import geoviews  # noqa
+            import cartopy.crs as ccrs
+        except:
+            raise SkipTest('xarray, rasterio, geoviews, or cartopy not available')
+        import hvplot.xarray  # noqa
+        self.da = (xr.open_rasterio(
+            'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif')
+            .sel(band=1))
+        self.crs = ccrs.epsg(self.da.crs.split('epsg:')[1])
+
+    def assertCRS(self, plot, proj='utm'):
+        assert plot.crs.proj4_params['proj'] == proj
+
+    def test_plot_with_crs_as_object(self):
+        plot = self.da.hvplot('x', 'y', crs=self.crs)
+        self.assertCRS(plot)
+
+    def test_plot_with_crs_as_proj_string(self):
+        plot = self.da.hvplot('x', 'y', crs=self.da.crs)
+        self.assertCRS(plot)
+
+    def test_plot_with_geo_as_true_crs_undefined(self):
+        plot = self.da.hvplot('x', 'y', geo=True)
+        self.assertCRS(plot)
+
+    def test_plot_with_crs_as_attr_str(self):
+        da = self.da.copy()
+        da.attrs = {'bar': self.crs}
+        plot = da.hvplot('x', 'y', crs='bar')
+        self.assertCRS(plot)
+
+    def test_plot_with_crs_as_nonexistent_attr_str(self):
+        with self.assertRaisesRegex(ValueError, "'foo' must be"):
+            self.da.hvplot('x', 'y', crs='foo')
+
+    def test_plot_with_geo_as_true_crs_no_crs_on_data_returns_default(self):
+        da = self.da.copy()
+        da.attrs = {'bar': self.crs}
+        plot = da.hvplot('x', 'y', geo=True)
+        self.assertCRS(plot, 'eqc')


### PR DESCRIPTION
Closes #82 

I'm not sure where to document this behavior but the goal was to only have defaults be a little more helpful so it should just do what is expected with whatever is given be it a proj4string, a cartopy.crs or a ds.attr name.