### PR TITLE
Add explicit project kwarg

### DIFF
--- a/examples/user_guide/Geographic_Data.ipynb
+++ b/examples/user_guide/Geographic_Data.ipynb
@@ -142,7 +142,7 @@
    "source": [
     "Note that when displaying raster data in a projection other than the one in which the data is stored, it is more accurate to render it as a ``quadmesh`` rather than an ``image``. As you can see above, a QuadMesh will project each original bin or pixel into the correct non-rectangular shape determined by the projection, accurately showing the geographic extent covered by each sample. An Image, on the other hand, will always be rectangularly aligned in the 2D plane, which requires warping and resampling the data in a way that allows efficient display but loses accuracy at the pixel level. Unfortunately, rendering a large QuadMesh using Bokeh can be very slow, but there are two useful alternatives for datasets too large to be practical as native QuadMeshes.\n",
     "\n",
-    "The first is using the ``datashade`` or ``rasterize`` options to regrid the data before rendering it, i.e., rendering the data on the backend and then sending a more efficient image-based representation to the browser:"
+    "The first is using the ``datashade`` or ``rasterize`` options to regrid the data before rendering it, i.e., rendering the data on the backend and then sending a more efficient image-based representation to the browser. One thing to note when using these operations is that it may be necessary to project the data **before** rasterizing it, e.g. to address wrapping issues. To do this provide ``project=True``, which will project the data before it is rasterized (this also works for other types and even when not using these operations). Another reason why this is important when rasterizing the data is that if the the CRS of the data does not match the displayed projection, all the data will be projected every time you zoom or pan, which can be very slow. Deciding whether to ``project`` is therefore a tradeoff between projecting the raw data ahead of time or accepting the overhead on dynamic zoom and pan actions."
    ]
   },
   {
@@ -155,7 +155,8 @@
     "\n",
     "rasm.hvplot.quadmesh(\n",
     "    'xc', 'yc', crs=ccrs.PlateCarree(), projection=ccrs.PlateCarree(),\n",
-    "    ylim=(0, 90), width=800, height=400, cmap='viridis', rasterize=True \n",
+    "    ylim=(0, 90), width=800, height=400, cmap='viridis', project=True,\n",
+    "    rasterize=True\n",
     ") * gv.feature.coastline"
    ]
   },
@@ -163,7 +164,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another option that's still relatively slow but avoids sending large data into your browser is to plot the data using ``contour`` and ``contourf`` visualizations, generating a line or filled contour with a discrete number of levels:"
+    "Another option that's still relatively slow for larger data but avoids sending large data into your browser is to plot the data using ``contour`` and ``contourf`` visualizations, generating a line or filled contour with a discrete number of levels:"
    ]
   },
   {

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -536,6 +536,13 @@ class HoloViewsConverter(param.Parameterized):
             else:
                 obj = method(x, y)
 
+        if self.crs and self.project:
+            # Apply projection before rasterizing
+            import cartopy.crs as ccrs
+            from geoviews import project
+            projection = self._plot_opts.get('projection', ccrs.GOOGLE_MERCATOR)
+            obj = project(obj, projection=projection)
+
         if not (self.datashade or self.rasterize):
             return obj
 
@@ -570,13 +577,6 @@ class HoloViewsConverter(param.Parameterized):
             eltype = 'Image'
             if 'cmap' in self._style_opts:
                 style['cmap'] = self._style_opts['cmap']
-
-        if self.crs and self.project:
-            # Apply projection before rasterizing
-            import cartopy.crs as ccrs
-            from geoviews import project
-            projection = self._plot_opts.get('projection', ccrs.GOOGLE_MERCATOR)
-            obj = project(obj, projection=projection)
 
         processed = operation(obj, **opts)
 

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -73,6 +73,8 @@ class HoloViewsConverter(param.Parameterized):
 
     _gridded_types = ['image', 'contour', 'contourf', 'quadmesh']
 
+    _geom_types = ['paths', 'polygons']
+
     _stats_types = ['hist', 'kde', 'violin', 'box']
 
     _data_options = ['x', 'y', 'kind', 'by', 'use_index', 'use_dask',
@@ -136,7 +138,7 @@ class HoloViewsConverter(param.Parameterized):
                  projection=None, global_extent=False, geo=False,
                  precompute=False, flip_xaxis=False, flip_yaxis=False,
                  dynspread=False, hover_cols=[], x_sampling=None,
-                 y_sampling=None, **kwds):
+                 y_sampling=None, project=False, **kwds):
 
         # Process data and related options
         self._process_data(kind, data, x, y, by, groupby, row, col,
@@ -148,6 +150,7 @@ class HoloViewsConverter(param.Parameterized):
         self.dynamic = dynamic
         self.geo = geo or crs or global_extent or projection
         self.crs = self._process_crs(data, crs) if self.geo else None
+        self.project = project
         self.row = row
         self.col = col
 
@@ -568,7 +571,7 @@ class HoloViewsConverter(param.Parameterized):
             if 'cmap' in self._style_opts:
                 style['cmap'] = self._style_opts['cmap']
 
-        if self.crs:
+        if self.crs and self.project:
             # Apply projection before rasterizing
             import cartopy.crs as ccrs
             from geoviews import project

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -148,11 +148,21 @@ class HoloViewsConverter(param.Parameterized):
         self.value_label = value_label
         self.group_label = group_label
         self.dynamic = dynamic
-        self.geo = geo or crs or global_extent or projection
+        self.geo = geo or crs or global_extent or projection or project
         self.crs = self._process_crs(data, crs) if self.geo else None
         self.project = project
         self.row = row
         self.col = col
+
+        # Import geoviews if geo-features requested
+        if self.geo:
+            try:
+                import geoviews # noqa
+            except ImportError:
+                raise ImportError('In order to use geo-related features '
+                                  'the geoviews library must be available. '
+                                  'It can be installed with:\n  conda '
+                                  'install -c pyviz geoviews')
 
         # Operations
         self.datashade = datashade


### PR DESCRIPTION
In https://github.com/pyviz/geoviews/issues/230 we worked out that the current behavior of always projecting all the data ahead of time before applying rasterize/datashade operations on it can be very suboptimal because it can result in very long initialization times. This PR disables this default behavior and instead adds an explicit ``project`` keyword argument to enable it.

- [x] Add documentation to discuss the tradeoffs between projecting ahead of time or not
- [x] Closes https://github.com/pyviz/hvplot/issues/95