### PR TITLE
Updating to use nbsite 0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,12 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# nbsite
+# these files normally shouldn't be checked in as they should be
+# dynamically built from notebooks
+doc/**/*.rst
+doc/**/*.ipynb
+doc/**/*.json
+# this dir contains the whole website and should not be checked in on master
+builtdocs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # We deliberately don't use travis's language=python option because
-# we install miniconda and use conda to get python. Additionally, 
+# we install miniconda and use conda to get python. Additionally,
 # Travis's auto-install of python doesn't work on osx images (see
 # https://github.com/travis-ci/travis-ci/issues/4729).
 language: generic
@@ -70,30 +70,19 @@ jobs:
       env: DESC="docs" CHANS_DEV="-c pyviz/label/dev -c pyviz -c ioam -c intake"
       script:
         - doit develop_install $CHANS_DEV -o doc
-        - conda uninstall nbsite --force
-        - pip install git+https://github.com/pyviz/nbsite.git --upgrade
         - bokeh sampledata
+        - nbsite generate-rst --org pyviz --project-name hvplot --offset 1 --skip '^.*Streaming.*$'
+        - nbsite build --what=html --output=builtdocs
 
-        # note: will vastly simplified in a future version of nbsite
-        - cd doc
-        - cp ./user_guide/Streaming.rst ./user_guide/Streaming.rst_bak
-        - nbsite_nbpagebuild.py ioam hvplot ../examples .
-        - cp ./user_guide/Streaming.rst_bak ./user_guide/Streaming.rst
-        - HV_DOC_HTML='true' sphinx-build -b html . ./_build/html
-        - nbsite_fix_links.py _build/html
-        - nbsite_cleandisthtml.py ./_build/html take_a_chance
-        - touch ./_build/html/.nojekyll
-        - cp -r ../examples/assets ./_build/html/assets
-        - cp -r ./assets/* ./_build/html/assets/
-        - cd ..
       deploy:
         provider: pages
         skip_cleanup: true
         github_token: $GITHUB_TOKEN
-        local_dir: ./doc/_build/html
+        local_dir: ./builtdocs
         fqdn: hvplot.pyviz.org
         on:
-          branch: master
+          tags: true
+          all_branches: true
 
     ########## END-USER PACKAGES ##########
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,9 +7,8 @@ authors = u'PyViz developers'
 copyright = u'2018 ' + authors
 description = 'A high-level plotting API for the PyData ecosystem built on HoloViews'
 
-# TODO: gah, version
-version = '0.0.1'
-release = '0.0.1'
+import hvplot
+version = release = hvplot.__version__
 
 html_static_path += ['_static']
 html_theme = 'sphinx_ioam_theme'
@@ -32,12 +31,12 @@ html_context.update({
     'DESCRIPTION': description,
     'AUTHOR': authors,
     # will work without this - for canonical (so can ignore when building locally or test deploying)
-    'WEBSITE_SERVER': 'https://pyviz.github.io/holoplot',
+    'WEBSITE_SERVER': 'https://pyviz.github.io/hvplot',
     'VERSION': version,
     'NAV': _NAV,
     'LINKS': _NAV,
     'SOCIAL': (
         ('Gitter', '//gitter.im/pyviz/pyviz'),
-        ('Github', '//github.com/pyviz/holoplot'),
+        ('Github', '//github.com/pyviz/hvplot'),
     )
 })

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ extras_require = {
     ],
     'examples': _examples_extra,
     'doc': _examples_extra + [
-        'nbsite',
+        'nbsite >=0.5.0',
         'sphinx_ioam_theme'
     ]
 }
@@ -169,7 +169,7 @@ extras_require['build'] = [
 ]
 
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
-    
+
 ########## metadata for setuptools ##########
 
 setup_args = dict(
@@ -177,7 +177,7 @@ setup_args = dict(
     version=get_setup_version("hvplot"),
     description='A high-level plotting API for the PyData ecosystem built on HoloViews.',
     long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",    
+    long_description_content_type="text/markdown",
     author= "Philipp Rudiger",
     author_email= "developers@pyviz.org",
     maintainer="PyViz developers",

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ extras_require = {
     ],
     'examples': _examples_extra,
     'doc': _examples_extra + [
-        'nbsite >=0.5.0',
+        'nbsite >=0.5.1',
         'sphinx_ioam_theme'
     ]
 }


### PR DESCRIPTION
After 0.5.0 of nbsite, evaluated notebooks live in `/doc` next to their dynamically generated `.rst` files. Lines are added to `.gitignore` to prevent accidental checking in of these files. Note that it is sometimes desirable to check in `doc/*.rst` files but it is preferable to generate them from notebooks. The workflow for re-evaluating a notebook and regenerating it's html is:

```bash
$ rm builtdocs/user_guide/Plotting.html
$ rm doc/user_guide/Plotting.ipynb
$ nbsite build --what=html --output=builtdocs
```

Upload the entire contents of `./builtdocs` to your server, or `gh-pages` branch to refresh your website.