### PR TITLE
Fixed reference to display function

### DIFF
--- a/examples/user_guide/Viewing.ipynb
+++ b/examples/user_guide/Viewing.ipynb
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To display the object from inside a function we can instead call the ``hvplot.display`` function. The ``display`` function also supports an ``display_id`` in the notebook (for JupyterLab and classic Jupyter Notebook versions >5.5), which allows us to obtain a handle for the plot:"
+    "To display the object from inside a function we can instead call the ``display`` function. The ``display`` function also supports an ``display_id`` in the notebook (for JupyterLab and classic Jupyter Notebook versions >5.5), which allows us to obtain a handle for the plot:"
    ]
   },
   {
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "handle = hvplot.display(violent_crime, display_id='example')"
+    "handle = display(violent_crime, display_id='example')"
    ]
   },
   {


### PR DESCRIPTION
The hvplot.display function was removed because ``display`` is a global in IPython.