### PR TITLE
Add min_count option for hexbin plots

### DIFF
--- a/hvplot/__init__.py
+++ b/hvplot/__init__.py
@@ -334,6 +334,9 @@ class hvPlot(object):
             Whether to display a colorbar
         reduce_function : function
             Function to compute statistics for hexbins
+        min_count : number
+            The display threshold before a bin is shown, by default bins with
+            a count of less than 1 are hidden
         **kwds : optional
             Keyword arguments to pass on to
             :py:meth:`hvplot.converter.HoloViewsConverter`.

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -178,7 +178,7 @@ class HoloViewsConverter(object):
         'area'     : ['y2'],
         'hist'     : ['bins', 'bin_range', 'normed', 'cumulative'],
         'heatmap'  : ['C', 'reduce_function', 'logz'],
-        'hexbin'   : ['C', 'reduce_function', 'gridsize', 'logz'],
+        'hexbin'   : ['C', 'reduce_function', 'gridsize', 'logz', 'min_count'],
         'dataset'  : ['columns'],
         'table'    : ['columns'],
         'image'    : ['z', 'logz'],
@@ -1105,6 +1105,8 @@ class HoloViewsConverter(object):
             opts['plot']['aggregator'] = self.kwds['reduce_function']
         if 'gridsize' in self.kwds:
             opts['plot']['gridsize'] = self.kwds['gridsize']
+        if 'min_count' in self.kwds:
+            opts['plot']['min_count'] = self.kwds['min_count']
         return HexTiles(data, [x, y], z or []).redim(**self._redim).opts(**opts)
 
     def bivariate(self, x, y, data=None):


### PR DESCRIPTION
Pretty much just added this option in to `_kind_options`, made sure the converter would pass it if specified, and copied relevant docs from holoviews.

Now you can do this:

<img width="966" alt="image" src="https://user-images.githubusercontent.com/8238804/54875579-e0126780-4e55-11e9-9287-4b70885eaefe.png">