### PR TITLE
Allow list types for xlim,ylim tuples

### DIFF
--- a/examples/user_guide/Geographic_Data.ipynb
+++ b/examples/user_guide/Geographic_Data.ipynb
@@ -89,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The GeoPanas support allows plotting ``GeoDataFrames`` containing ``'Point'``, ``'Polygon'``, ``'LineString'`` and ``'LineRing'`` geometries, but not ones containing a mixture of different geometry types. Calling ``.hvplot`` will automatically figure out the geometry type to plot, but it also possible to call ``.hvplot.points``, ``.hvplot.polygons``, and ``.hvplot.paths`` explicitly.\n",
+    "The GeoPandas support allows plotting ``GeoDataFrames`` containing ``'Point'``, ``'Polygon'``, ``'LineString'`` and ``'LineRing'`` geometries, but not ones containing a mixture of different geometry types. Calling ``.hvplot`` will automatically figure out the geometry type to plot, but it also possible to call ``.hvplot.points``, ``.hvplot.polygons``, and ``.hvplot.paths`` explicitly.\n",
     "\n",
     "When plotting polygons it will automatically color by a dimension, but it is also possible to declare a specific column with the ``c`` keyword:"
    ]
@@ -199,22 +199,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -130,7 +130,7 @@ class HoloViewsConverter(object):
         e.g. '%.3f', and bokeh TickFormatter)
     xlabel/ylabel/clabel (default=None): str
         Axis labels for the x-axis, y-axis, and colorbar
-    xlim/ylim (default=None): tuple
+    xlim/ylim (default=None): tuple or list
         Plot limits of the x- and y-axis
     xticks/yticks (default=None): int or list
         Ticks along x- and y-axis specified as an integer, list of
@@ -341,9 +341,9 @@ class HoloViewsConverter(object):
         if clabel is not None:
             plot_opts['clabel'] = clabel
         if xlim is not None:
-            plot_opts['xlim'] = xlim
+            plot_opts['xlim'] = tuple(xlim)
         if ylim is not None:
-            plot_opts['ylim'] = ylim
+            plot_opts['ylim'] = tuple(ylim)
         if padding is not None:
             plot_opts['padding'] = padding
         if xformatter is not None:


### PR DESCRIPTION
Addresses https://github.com/pyviz/datashader/issues/766 . @philippjfr , not sure if you'd want to allow *only* list types, or any sequence as here.  An alternative to this PR would be to change param.Tuple to coerce inputs to tuples in general, but that does cut down on detecting some genuine error conditions, so I made this more conservative PR instead.