### PR TITLE
Only include numeric columns by default if available in data

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -919,6 +919,12 @@ class HoloViewsConverter(object):
         y = y or self.y
         if not y:
             ys = [c for c in data.columns if c not in [x]+self.by+self.groupby]
+            if len(ys) > 1 and self.datatype == 'pandas':
+                # if columns have different dtypes, only include numeric columns
+                from pandas.api.types import is_numeric_dtype as isnum
+                num_ys = [col for col in data.columns if isnum(data[col])]
+                if len(num_ys) >= 1:
+                    ys = num_ys
             y = ys[0] if len(ys) == 1 else ys
         return data, x, y
 

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -919,7 +919,7 @@ class HoloViewsConverter(object):
         y = y or self.y
         if not y:
             ys = [c for c in data.columns if c not in [x]+self.by+self.groupby]
-            if len(ys) > 1 and self.datatype == 'pandas':
+            if len(ys) > 1:
                 # if columns have different dtypes, only include numeric columns
                 from pandas.api.types import is_numeric_dtype as isnum
                 num_ys = [col for col in data.columns if isnum(data[col])]

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -36,9 +36,9 @@ class TestChart2D(ComparisonTestCase):
         plot = self.df.hvplot.heatmap()
         self.assertEqual(plot, HeatMap((['x', 'y'], [0, 1, 2], self.df.values),
                                        ['columns', 'index'], 'value'))
-        
 
-        
+
+
 class TestChart1D(ComparisonTestCase):
 
     def setUp(self):
@@ -152,3 +152,16 @@ class TestChart1D(ComparisonTestCase):
                          'lower': element(self.cat_only_df, 'index', 'lower').redim(lower='value'),
                         }, 'Variable')
         self.assertEqual(plot, obj)
+
+class TestChart1DDask(TestChart1D):
+
+    def setUp(self):
+        super().setUp()
+        try:
+            import dask.dataframe as dd
+        except:
+            raise SkipTest('Dask not available')
+        patch('dask')
+        self.df = dd.from_pandas(self.df, npartitions=2)
+        self.cat_df = dd.from_pandas(self.cat_df, npartitions=3)
+        self.cat_only_df = dd.from_pandas(self.cat_only_df, npartitions=1)

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -50,6 +50,8 @@ class TestChart1D(ComparisonTestCase):
         self.df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=['x', 'y'])
         self.cat_df = pd.DataFrame([[1, 2, 'A'], [3, 4, 'B'], [5, 6, 'C']],
                                    columns=['x', 'y', 'category'])
+        self.cat_only_df = pd.DataFrame([['A', 'a'], ['B', 'b'], ['C', 'c']],
+                                        columns=['upper', 'lower'])
 
     @parameterized.expand([('line', Curve), ('area', Area), ('scatter', Scatter)])
     def test_wide_chart(self, kind, element):
@@ -134,3 +136,19 @@ class TestChart1D(ComparisonTestCase):
         plot = self.cat_df.hvplot.hist('y', legend='left')
         opts = Store.lookup_options('bokeh', plot, 'plot')
         self.assertEqual(opts.kwargs['legend_position'], 'left')
+
+    @parameterized.expand([('line', Curve), ('area', Area), ('scatter', Scatter)])
+    def test_only_includes_num_chart(self, kind, element):
+        plot = self.cat_df.hvplot(kind=kind)
+        obj = NdOverlay({'x': element(self.cat_df, 'index', 'x').redim(x='value'),
+                         'y': element(self.cat_df, 'index', 'y').redim(y='value'),
+                        }, 'Variable')
+        self.assertEqual(plot, obj)
+
+    @parameterized.expand([('line', Curve), ('area', Area), ('scatter', Scatter)])
+    def test_includes_str_if_no_num_chart(self, kind, element):
+        plot = self.cat_only_df.hvplot(kind=kind)
+        obj = NdOverlay({'upper': element(self.cat_only_df, 'index', 'upper').redim(upper='value'),
+                         'lower': element(self.cat_only_df, 'index', 'lower').redim(lower='value'),
+                        }, 'Variable')
+        self.assertEqual(plot, obj)


### PR DESCRIPTION
Closes #241 

Not quite sure if this is possible with a dask dataframe.

<img width="1096" alt="Screen Shot 2019-07-19 at 3 09 50 PM" src="https://user-images.githubusercontent.com/4806877/61559281-50617c00-aa37-11e9-971f-b4fce2210497.png">
