### PR TITLE
Fix label for xr.Dataset

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -638,7 +638,10 @@ class HoloViewsConverter(object):
         if da is not None and attr_labels:
             try:
                 var_tuples = [(var, da[var].attrs) for var in da.coords]
-                var_tuples.append((da.name, da.attrs))
+                if isinstance(da, xr.Dataset):
+                    var_tuples.extend([(var, da[var].attrs) for var in da.data_vars])
+                else:
+                    var_tuples.append((da.name, da.attrs))
                 labels = {}
                 units = {}
                 for var_name, var_attrs in var_tuples:

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -139,8 +139,11 @@ class HoloViewsConverter(object):
         ticks positions, or list of tuples of the tick positions and labels
     width (default=800)/height (default=300): int
         The width and height of the plot in pixels
-    attr_labels (default=True): bool
-        Whether to use an xarray object's attributes as labels
+    attr_labels (default=None): bool
+        Whether to use an xarray object's attributes as labels, defaults to
+        None to allow best effort without throwing a warning. Set to True
+        to see warning if the attrs can't be found, set to False to disable
+        the behavior.
     sort_date (default=True): bool
         Whether to sort the x-axis by date before plotting
 
@@ -279,7 +282,7 @@ class HoloViewsConverter(object):
                  precompute=False, flip_xaxis=None, flip_yaxis=None,
                  dynspread=False, hover_cols=[], x_sampling=None,
                  y_sampling=None, project=False, tools=[],
-                 attr_labels=True, coastline=False, tiles=False,
+                 attr_labels=None, coastline=False, tiles=False,
                  sort_date=True, **kwds):
 
         # Process data and related options
@@ -635,7 +638,7 @@ class HoloViewsConverter(object):
         self.streaming = streaming
         self.hover_cols = hover_cols
 
-        if da is not None and attr_labels:
+        if da is not None and attr_labels is True or attr_labels is None:
             try:
                 var_tuples = [(var, da[var].attrs) for var in da.coords]
                 if isinstance(da, xr.Dataset):
@@ -654,9 +657,9 @@ class HoloViewsConverter(object):
                 self._redim = self._merge_redim(labels, 'label')
                 self._redim = self._merge_redim(units, 'unit')
             except Exception as e:
-                param.main.warning('Unable to auto label using xarray attrs '
-                                   'because {e}; suppress this warning '
-                                   'with attr_labels=False.'.format(e=e))
+                if attr_labels is True:
+                    param.main.warning('Unable to auto label using xarray attrs '
+                                       'because {e}'.format(e=e))
 
     def _process_plot(self, color):
         kind = self.kind

--- a/hvplot/tests/testgridplots.py
+++ b/hvplot/tests/testgridplots.py
@@ -34,6 +34,8 @@ class TestGridPlots(ComparisonTestCase):
         self.xarr_with_attrs.x.attrs['long_name'] = 'Declination'
         self.xarr_with_attrs.y.attrs['long_name'] = 'Right Ascension'
 
+        self.xds_with_attrs = xr.Dataset({'light': self.xarr_with_attrs })
+
     def test_rgb_dataarray_no_args(self):
         rgb = self.da_rgb.hvplot()
         self.assertEqual(rgb, RGB(([0, 1], [0, 1])+tuple(self.da_rgb.values)))
@@ -88,6 +90,13 @@ class TestGridPlots(ComparisonTestCase):
         self.assertEqual(img.vdims[0].unit, 'lm')
         self.assertEqual(img.vdims[0].range, (0, 2))
 
+    def test_table_infer_dimension_params_from_xarray_ds_attrs(self):
+        table = self.xds_with_attrs.hvplot.dataset()
+        self.assertEqual(table.kdims[0].label, 'Declination')
+        self.assertEqual(table.kdims[1].label, 'Right Ascension')
+        self.assertEqual(table.kdims[2].label, 'luminosity')
+        self.assertEqual(table.kdims[2].unit, 'lm')
+
     def test_points_infer_dimension_params_from_xarray_attrs(self):
         points = self.xarr_with_attrs.hvplot.points(c='value', clim=(0, 2))
         self.assertEqual(points.kdims[0].label, 'Declination')
@@ -95,14 +104,14 @@ class TestGridPlots(ComparisonTestCase):
         self.assertEqual(points.vdims[0].label, 'luminosity')
         self.assertEqual(points.vdims[0].unit, 'lm')
         self.assertEqual(points.vdims[0].range, (0, 2))
-        
+
     def test_dataset_infer_dimension_params_from_xarray_attrs(self):
         ds = self.xarr_with_attrs.hvplot.dataset()
         self.assertEqual(ds.kdims[0].label, 'Declination')
         self.assertEqual(ds.kdims[1].label, 'Right Ascension')
         self.assertEqual(ds.kdims[2].label, 'luminosity')
         self.assertEqual(ds.kdims[2].unit, 'lm')
-        
+
     def test_table_infer_dimension_params_from_xarray_attrs(self):
         table = self.xarr_with_attrs.hvplot.dataset()
         self.assertEqual(table.kdims[0].label, 'Declination')


### PR DESCRIPTION
Closes #261 

The last commit in this PR makes the warning only show if the user explicitly sets `attr_labels` to `True`. Not sure whether or not that change is acceptable. But I kept the commit separate so that it is easily revertable if people don't like that idea. 
