### PR TITLE
Adding derived datatime for xarray

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -555,7 +555,6 @@ class HoloViewsConverter(object):
             else:
                 other_dims = []
             da = data
-            print('processing')
             data, x, y, by_new, groupby_new = process_xarray(
                 data, x, y, by, groupby, use_dask, persist, gridded,
                 label, value_label, other_dims)
@@ -1051,7 +1050,6 @@ class HoloViewsConverter(object):
     def chart(self, element, x, y, data=None):
         "Helper method for simple x vs. y charts"
         data, x, y = self._process_args(data, x, y)
-        print(data.head(), x, y)
         if x and y and not isinstance(y, (list, tuple)):
             return self.single_chart(element, x, y, data)
         elif x and y and len(y) == 1:

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -29,7 +29,8 @@ from holoviews.util.transform import dim
 
 from .util import (
     is_series, is_dask, is_intake, is_streamz, is_xarray, process_crs,
-    process_intake, process_xarray, check_library, is_geopandas
+    process_intake, process_xarray, check_library, is_geopandas,
+    process_derived_datetime,
 )
 
 renderer = hv.renderer('bokeh')
@@ -574,6 +575,7 @@ class HoloViewsConverter(object):
 
         if gridded_data:
             not_found = [g for g in groupby if g not in data.coords]
+            not_found, _ = process_derived_datetime(data, not_found)
             data_vars = list(data.data_vars) if isinstance(data, xr.Dataset) else [data.name]
             indexes = list(data.coords)
             self.variables = list(data.coords) + data_vars

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -555,6 +555,7 @@ class HoloViewsConverter(object):
             else:
                 other_dims = []
             da = data
+            print('processing')
             data, x, y, by_new, groupby_new = process_xarray(
                 data, x, y, by, groupby, use_dask, persist, gridded,
                 label, value_label, other_dims)
@@ -575,7 +576,7 @@ class HoloViewsConverter(object):
 
         if gridded_data:
             not_found = [g for g in groupby if g not in data.coords]
-            not_found, _ = process_derived_datetime(data, not_found)
+            not_found, *_ = process_derived_datetime(data, not_found)
             data_vars = list(data.data_vars) if isinstance(data, xr.Dataset) else [data.name]
             indexes = list(data.coords)
             self.variables = list(data.coords) + data_vars
@@ -1050,6 +1051,7 @@ class HoloViewsConverter(object):
     def chart(self, element, x, y, data=None):
         "Helper method for simple x vs. y charts"
         data, x, y = self._process_args(data, x, y)
+        print(data.head(), x, y)
         if x and y and not isinstance(y, (list, tuple)):
             return self.single_chart(element, x, y, data)
         elif x and y and len(y) == 1:

--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -133,7 +133,7 @@ class TestProcessXarray(TestCase):
         assert x == 'time'
         assert y == ['air']
         assert not by
-        assert groupby == ['lat', 'lon']
+        assert groupby == ['lon', 'lat']
 
     def test_process_3d_xarray_dataset_with_coords_as_gridded(self):
         import xarray as xr
@@ -164,26 +164,28 @@ class TestProcessXarray(TestCase):
         assert groupby == ['time']
 
     def test_process_xarray_dataset_with_by_as_derived_datetime(self):
-        import xarray as xr
+        import pandas as pd
 
         data = self.ds.mean(dim=['lat', 'lon'])
         kwargs = self.default_kwargs
         kwargs.update(gridded=False, y='air', by=['time.hour'])
 
-        data, x, y, by, groupby = process_xarray(data=self.ds, **kwargs)
+        data, x, y, by, groupby = process_xarray(data=data, **kwargs)
+        assert isinstance(data, pd.DataFrame)
         assert x == 'time'
         assert y == 'air'
         assert by == ['time.hour']
         assert not groupby
 
     def test_process_xarray_dataset_with_x_as_derived_datetime(self):
-        import xarray as xr
+        import pandas as pd
 
         data = self.ds.mean(dim=['lat', 'lon'])
         kwargs = self.default_kwargs
         kwargs.update(gridded=False, y='air', x='time.dayofyear')
 
-        data, x, y, by, groupby = process_xarray(data=self.ds, **kwargs)
+        data, x, y, by, groupby = process_xarray(data=data, **kwargs)
+        assert isinstance(data, pd.DataFrame)
         assert x == 'time.dayofyear'
         assert y == 'air'
         assert not by

--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -41,8 +41,8 @@ class TestProcessXarray(TestCase):
         assert isinstance(data, pd.DataFrame)
         assert x == 'index'
         assert y == ['value']
-        assert by == []
-        assert groupby == []
+        assert not by
+        assert not groupby
 
     def test_process_1d_xarray_dataarray_with_coords(self):
         import xarray as xr
@@ -57,8 +57,8 @@ class TestProcessXarray(TestCase):
         assert isinstance(data, pd.DataFrame)
         assert x == 'day'
         assert y == ['value']
-        assert by == []
-        assert groupby == []
+        assert not by
+        assert not groupby
 
     def test_process_1d_xarray_dataarray_with_coords_and_name(self):
         import xarray as xr
@@ -74,8 +74,8 @@ class TestProcessXarray(TestCase):
         assert isinstance(data, pd.DataFrame)
         assert x == 'day'
         assert y == ['temp']
-        assert by == []
-        assert groupby == []
+        assert not by
+        assert not groupby
 
     def test_process_2d_xarray_dataarray_with_no_coords(self):
         import xarray as xr
@@ -87,8 +87,8 @@ class TestProcessXarray(TestCase):
         assert isinstance(data, pd.DataFrame)
         assert x == 'index'
         assert y == ['value']
-        assert by == []
-        assert groupby == []
+        assert not by
+        assert not groupby
 
     def test_process_2d_xarray_dataarray_with_no_coords_as_gridded(self):
         import xarray as xr
@@ -103,8 +103,8 @@ class TestProcessXarray(TestCase):
         assert list(data.data_vars.keys()) == ['value']
         assert x == 'dim_1'
         assert y == 'dim_0'
-        assert by is None
-        assert groupby is None
+        assert not by
+        assert not groupby
 
     def test_process_2d_xarray_dataarray_with_coords_as_gridded(self):
         import xarray as xr
@@ -122,8 +122,8 @@ class TestProcessXarray(TestCase):
         assert list(data.data_vars.keys()) == ['value']
         assert x == 'y'
         assert y == 'x'
-        assert by is None
-        assert groupby is None
+        assert not by
+        assert not groupby
 
     def test_process_3d_xarray_dataset_with_coords(self):
         import pandas as pd
@@ -132,8 +132,8 @@ class TestProcessXarray(TestCase):
         assert isinstance(data, pd.DataFrame)
         assert x == 'time'
         assert y == ['air']
-        assert by == []
-        assert groupby == ['lon', 'lat']
+        assert not by
+        assert groupby == ['lat', 'lon']
 
     def test_process_3d_xarray_dataset_with_coords_as_gridded(self):
         import xarray as xr
@@ -160,5 +160,31 @@ class TestProcessXarray(TestCase):
         assert list(data.data_vars.keys()) == ['air']
         assert x == 'lon'
         assert y == 'lat'
-        assert by is None
+        assert not by
         assert groupby == ['time']
+
+    def test_process_xarray_dataset_with_by_as_derived_datetime(self):
+        import xarray as xr
+
+        data = self.ds.mean(dim=['lat', 'lon'])
+        kwargs = self.default_kwargs
+        kwargs.update(gridded=False, y='air', by=['time.hour'])
+
+        data, x, y, by, groupby = process_xarray(data=self.ds, **kwargs)
+        assert x == 'time'
+        assert y == 'air'
+        assert by == ['time.hour']
+        assert not groupby
+
+    def test_process_xarray_dataset_with_x_as_derived_datetime(self):
+        import xarray as xr
+
+        data = self.ds.mean(dim=['lat', 'lon'])
+        kwargs = self.default_kwargs
+        kwargs.update(gridded=False, y='air', x='time.dayofyear')
+
+        data, x, y, by, groupby = process_xarray(data=self.ds, **kwargs)
+        assert x == 'time.dayofyear'
+        assert y == 'air'
+        assert not by
+        assert not groupby

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -312,6 +312,12 @@ def process_xarray(data, x, y, by, groupby, use_dask, persist, gridded, label, v
         elif not x and not y:
             x, y = dims[0], data_vars
 
+        for var in [x, y]:
+            if isinstance(var, list):
+                all_vars.extend(var)
+            elif isinstance(var, str):
+                all_vars.append(var)
+
         covered_dims = []
         for var in all_vars:
             if var in dataset.coords:

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -321,7 +321,7 @@ def process_xarray(data, x, y, by, groupby, use_dask, persist, gridded, label, v
         covered_dims = []
         for var in all_vars:
             if var in dataset.coords:
-                covered_dims.extend(dataset.dims)
+                covered_dims.extend(dataset[var].dims)
         leftover_dims = [dim for dim in dims if dim not in covered_dims + all_vars]
 
         if by is None:


### PR DESCRIPTION
Closes #54 

Allows using derived datetime for xarray objects

```python
import xarray as xr
import hvplot.xarray
ds = xr.tutorial.open_dataset('air_temperature')
plot = ds.hvplot.violin(y='air', by='time.month')
plot
```
<img width="1018" alt="Screen Shot 2019-07-26 at 11 08 30 AM" src="https://user-images.githubusercontent.com/4806877/61961659-d6307a80-af95-11e9-8f70-8c174e59d776.png">

```python
ds.mean(dim=['lat', 'lon']).hvplot(by='time.hour')
```

<img width="1017" alt="Screen Shot 2019-07-26 at 11 08 38 AM" src="https://user-images.githubusercontent.com/4806877/61961664-d892d480-af95-11e9-9287-3a73e497c312.png">

```python
data.hvplot.scatter(y='air', x='time.dayofyear', by='time.year')
```

<img width="1021" alt="Screen Shot 2019-07-26 at 2 29 33 PM" src="https://user-images.githubusercontent.com/4806877/61973340-d179bf80-afb1-11e9-8827-6719f27b6647.png">
