### PR TITLE
Using attrs to set default x and y for gridded outputs

### DIFF
--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -148,3 +148,17 @@ class TestProcessXarray(TestCase):
         assert y == 'lat'
         assert by is None
         assert groupby == ['time']
+
+    def test_process_3d_xarray_dataset_with_coords_as_gridded_uses_axis_to_get_defaults(self):
+        import xarray as xr
+
+        kwargs = self.default_kwargs
+        kwargs.update(gridded=True)
+
+        data, x, y, by, groupby = process_xarray(data=self.ds, **kwargs)
+        assert isinstance(data, xr.Dataset)
+        assert list(data.data_vars.keys()) == ['air']
+        assert x == 'lon'
+        assert y == 'lat'
+        assert by is None
+        assert groupby == ['time']

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -261,6 +261,13 @@ def process_xarray(data, x, y, by, groupby, use_dask, persist, gridded, label, v
         if len(dims) < 2:
             dims += [dim for dim in list(data.dims)[::-1] if dim not in dims]
         if not (x or y):
+            for c in dataset.coords:
+                axis = dataset[c].attrs.get('axis', '')
+                if axis.lower() == 'x':
+                    x = c
+                elif axis.lower() == 'y':
+                    y = c
+        if not (x or y):
             x, y = index_dims[:2] if len(index_dims) > 1 else dims[:2]
         elif x and not y:
             y = [d for d in dims if d != x][0]


### PR DESCRIPTION
After #173 went in, I realized that there is more info in the coords attrs that can be used to set better defaults. 

This PR:
<img width="1022" alt="Screen Shot 2019-07-26 at 1 11 43 PM" src="https://user-images.githubusercontent.com/4806877/61968809-ee5cc580-afa6-11e9-8b70-204525aae0eb.png">

For reference, this is the output of the same call on master:
<img width="1012" alt="Screen Shot 2019-07-26 at 1 19 57 PM" src="https://user-images.githubusercontent.com/4806877/61969278-1d276b80-afa8-11e9-9c0a-81a7dd569973.png">
