### PR TITLE
If datashade=True then hover should be false by default

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -85,8 +85,9 @@ class HoloViewsConverter(object):
         Whether to flip the axis left to right or up and down respectively
     grid (default=False): boolean
         Whether to show a grid
-    hover (default=True): boolean
-        Whether to show hover tooltips
+    hover : boolean
+        Whether to show hover tooltips, default is True unless datashade is
+        True in which case hover is False by default
     hover_cols (default=[]): list
         Additional columns to add to the hover tool
     invert (default=False): boolean
@@ -279,7 +280,7 @@ class HoloViewsConverter(object):
                  crs=None, fields={}, groupby=None, dynamic=True,
                  grid=None, legend=None, rot=None, title=None,
                  xlim=None, ylim=None, clim=None,
-                 logx=None, logy=None, loglog=None, hover=True,
+                 logx=None, logy=None, loglog=None, hover=None,
                  subplots=False, label=None, invert=False,
                  stacked=False, colorbar=None, fontsize=None,
                  datashade=False, rasterize=False,
@@ -430,6 +431,8 @@ class HoloViewsConverter(object):
             plot_opts[axis] = rot
 
         tools = list(tools) or list(plot_opts.get('tools', []))
+        if hover is None:
+            hover = not self.datashade
         if hover and not any(t for t in tools if isinstance(t, HoverTool)
                              or t == 'hover'):
             tools.append('hover')

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -79,6 +79,16 @@ class TestDatashader(ComparisonTestCase):
         color_key = {'A': '#ff0000', 'B': '#00ff00', 'C': '#0000ff'}
         self.df.hvplot.points(x='x', y='y', by='category', cmap=color_key, datashade=True)
 
+    def test_when_datashade_is_true_set_hover_to_false_by_default(self):
+        plot = self.df.hvplot(x='x', y='y', datashade=True)
+        opts = Store.lookup_options('bokeh', plot[0], 'plot').kwargs
+        assert 'hover' not in opts.get('tools')
+
+    def test_when_datashade_is_true_hover_can_still_be_true(self):
+        plot = self.df.hvplot(x='x', y='y', datashade=True, hover=True)
+        opts = Store.lookup_options('bokeh', plot[0], 'plot').kwargs
+        assert 'hover' in opts.get('tools')
+
 
 class TestChart2D(ComparisonTestCase):
 


### PR DESCRIPTION
Closes #204 

This is kind of a half-solution. It just turns off the hover when datashade is true if the user doesn't specifically ask for it. 