### PR TITLE
Allow datashade/rasterize even when c is same as x or y

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -726,7 +726,7 @@ class HoloViewsConverter(object):
         if 'color' in kwds or 'c' in kwds:
             color = kwds.pop('color', kwds.pop('c', None))
             if isinstance(color, (np.ndarray, pd.Series)) or \
-                (self.datashade or self.rasterize and color in [self.x, self.y]):
+                ((self.datashade or self.rasterize) and color in [self.x, self.y]):
                 self.data = self.data.assign(_color=self.data[color])
                 style_opts['color'] = '_color'
                 self.variables.append('_color')
@@ -758,7 +758,7 @@ class HoloViewsConverter(object):
         if 'size' in kwds or 's' in kwds:
             size = kwds.pop('size', kwds.pop('s', None))
             if isinstance(size, (np.ndarray, pd.Series)) or \
-                (self.datashade or self.rasterize and size in [self.x, self.y]):
+                ((self.datashade or self.rasterize) and size in [self.x, self.y]):
                 self.data = self.data.assign('_size', np.sqrt(size))
                 style_opts['size'] = '_size'
                 self.variables.append('_size')

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -734,11 +734,12 @@ class HoloViewsConverter(object):
                 style_opts['color'] = color
             else:
                 style_opts['color'] = color
-                if 'c' in self._kind_options.get(kind, []) and (color in self.variables):
-                    if self.data[color].dtype.kind in 'OSU':
-                        cmap = cmap or self._default_cmaps['categorical']
-                    else:
-                        cmap = cmap or self._default_cmaps['linear']
+
+            if 'c' in self._kind_options.get(kind, []) and (color in self.variables):
+                if self.data[color].dtype.kind in 'OSU':
+                    cmap = cmap or self._default_cmaps['categorical']
+                else:
+                    cmap = cmap or self._default_cmaps['linear']
 
         if isinstance(cmap, str) and cmap in self._default_cmaps:
             cmap = self._default_cmaps[cmap]

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -58,6 +58,11 @@ class TestDatashader(ComparisonTestCase):
         opts = Store.lookup_options('bokeh', plot, 'style').kwargs
         self.assertEqual(opts.get('cmap'), 'kbc_r')
 
+    def test_rasterize_default_cmap(self):
+        plot = self.df.hvplot.scatter('x', 'y', dynamic=False, rasterize=True)
+        opts = Store.lookup_options('bokeh', plot, 'style').kwargs
+        self.assertEqual(opts.get('cmap'), 'kbc_r')
+
     @parameterized.expand([('aspect',), ('data_aspect',)])
     def test_aspect_with_datashade(self, opt):
         plot = self.df.hvplot(x='x', y='y', datashade=True, **{opt: 2})

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -27,19 +27,29 @@ class TestDatashader(ComparisonTestCase):
         self.assertIsInstance(agg, count_cat)
         self.assertEqual(agg.column, 'category')
 
-    def test_rasterize_color_dim(self):
+    @parameterized.expand([('rasterize',), ('datashade',)])
+    def test_color_dim_with_default_agg(self, operation):
         from datashader.reductions import mean
-        dmap = self.df.hvplot.scatter('x', 'y', c='number', rasterize=True)
+        dmap = self.df.hvplot.scatter('x', 'y', c='number', **{operation: True})
         agg = dmap.callback.inputs[0].callback.operation.p.aggregator
         self.assertIsInstance(agg, mean)
         self.assertEqual(agg.column, 'number')
 
-    def test_rasterize_color_dim_with_string_agg(self):
+    @parameterized.expand([('rasterize',), ('datashade',)])
+    def test_color_dim_with_string_agg(self, operation):
         from datashader.reductions import sum
-        dmap = self.df.hvplot.scatter('x', 'y', c='number', rasterize=True, aggregator='sum')
+        dmap = self.df.hvplot.scatter('x', 'y', c='number', aggregator='sum', **{operation: True})
         agg = dmap.callback.inputs[0].callback.operation.p.aggregator
         self.assertIsInstance(agg, sum)
         self.assertEqual(agg.column, 'number')
+
+    @parameterized.expand([('rasterize',), ('datashade',)])
+    def test_color_dim_also_an_axis(self, operation):
+        from datashader.reductions import mean
+        dmap = self.df.hvplot.scatter('x', 'y', c='y', **{operation: True})
+        agg = dmap.callback.inputs[0].callback.operation.p.aggregator
+        self.assertIsInstance(agg, mean)
+        self.assertEqual(agg.column, '_color')
 
     @parameterized.expand([('aspect',), ('data_aspect',)])
     def test_aspect_with_datashade(self, opt):

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -51,6 +51,11 @@ class TestDatashader(ComparisonTestCase):
         self.assertIsInstance(agg, mean)
         self.assertEqual(agg.column, '_color')
 
+    def test_rasterize_color_dim_with_new_column_gets_default_cmap(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='y', dynamic=False, rasterize=True)
+        opts = Store.lookup_options('bokeh', plot, 'style').kwargs
+        self.assertEqual(opts.get('cmap'), 'kbc_r')
+
     @parameterized.expand([('aspect',), ('data_aspect',)])
     def test_aspect_with_datashade(self, opt):
         plot = self.df.hvplot(x='x', y='y', datashade=True, **{opt: 2})

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -46,10 +46,12 @@ class TestDatashader(ComparisonTestCase):
     @parameterized.expand([('rasterize',), ('datashade',)])
     def test_color_dim_also_an_axis(self, operation):
         from datashader.reductions import mean
+        original_data = self.df.copy(deep=True)
         dmap = self.df.hvplot.scatter('x', 'y', c='y', **{operation: True})
         agg = dmap.callback.inputs[0].callback.operation.p.aggregator
         self.assertIsInstance(agg, mean)
         self.assertEqual(agg.column, '_color')
+        assert original_data.equals(self.df)
 
     def test_rasterize_color_dim_with_new_column_gets_default_cmap(self):
         plot = self.df.hvplot.scatter('x', 'y', c='y', dynamic=False, rasterize=True)


### PR DESCRIPTION
Closes: #226 

Note that this PR also fixes some instances of hvplot altering the input data.

```python
import holoviews as hv
import hvplot.pandas
from bokeh.sampledata.autompg import autompg
hv.extension('bokeh')
autompg.hvplot.scatter(x='mpg', y='yr', c='yr', datashade=True, dynspread=True)
autompg.hvplot.scatter(x='mpg', y='yr', c='yr', rasterize=True, y_sampling=1, x_sampling=1)
```

<img width="1022" alt="Screen Shot 2019-08-05 at 1 42 35 PM" src="https://user-images.githubusercontent.com/4806877/62483929-e6f7a200-b786-11e9-9ba6-8ee7ed984bea.png">
