### PR TITLE
Fixing lim should be used as range when datashading

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -921,6 +921,10 @@ class HoloViewsConverter(object):
             opts['x_sampling'] = self.x_sampling
         if self.y_sampling:
             opts['y_sampling'] = self.y_sampling
+        if self._plot_opts.get('xlim') is not None:
+            opts['x_range'] = self._plot_opts['xlim']
+        if self._plot_opts.get('ylim') is not None:
+            opts['y_range'] = self._plot_opts['ylim']
         if not self.dynamic:
             opts['dynamic'] = self.dynamic
 

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -111,6 +111,11 @@ class TestDatashader(ComparisonTestCase):
         opts = Store.lookup_options('bokeh', plot[0], 'plot').kwargs
         assert 'hover' in opts.get('tools')
 
+    def test_xlim_affects_x_range(self):
+        data = pd.DataFrame(np.random.randn(100).cumsum())
+        img = data.hvplot(xlim=(0, 20000), datashade=True, dynamic=False)
+        assert img.range(0) == (0, 20000)
+
 
 class TestChart2D(ComparisonTestCase):
 


### PR DESCRIPTION
The axis zoom was happening after datashading when it should have been happening before.

Closes: #177 

```python
import numpy as np
import pandas as pd
import hvplot.pandas

pd.DataFrame(y).hvplot(datashade=True, xlim=(0, 20000))
```

Before this PR:

<img width="1016" alt="Screen Shot 2019-08-07 at 9 49 14 AM" src="https://user-images.githubusercontent.com/4806877/62628145-bd5e8800-b8f8-11e9-8221-583e1f021785.png">

After this PR:

<img width="1020" alt="Screen Shot 2019-08-07 at 9 48 45 AM" src="https://user-images.githubusercontent.com/4806877/62628124-b6d01080-b8f8-11e9-9982-faea230fd190.png">