### PR TITLE
Fixing color order should match node order

### DIFF
--- a/hvplot/networkx.py
+++ b/hvplot/networkx.py
@@ -75,7 +75,7 @@ def _from_networkx(G, positions, nodes=None, cls=Graph, **kwargs):
     node_columns = defaultdict(list)
 
     # Unpack node positions
-    for idx, pos in sorted(positions.items()):
+    for idx, pos in positions.items():
         node = G.nodes.get(idx)
         if node is None:
             continue

--- a/hvplot/tests/testnetworkx.py
+++ b/hvplot/tests/testnetworkx.py
@@ -1,0 +1,26 @@
+from unittest import TestCase, SkipTest
+
+try:
+    import numpy as np
+    import networkx as nx
+    import hvplot.networkx as hvnx
+except:
+    raise SkipTest('NetworkX not available')
+
+class TestOptions(TestCase):
+
+    def setUp(self):
+        # Create nodes (1-10) in unsorted order
+        nodes = np.array([1, 4, 5, 10, 8, 9, 3, 7, 2, 6])
+        edges = [*zip(nodes[:-1], nodes[1:])]
+
+        g = nx.Graph()
+        g.add_nodes_from(nodes)
+        g.add_edges_from(edges)
+
+        self.nodes = nodes
+        self.g = g
+
+    def test_nodes_are_not_sorted(self):
+        plot = hvnx.draw(self.g)
+        assert all(self.nodes == plot.nodes.dimension_values(2))


### PR DESCRIPTION
Closes: #223 

Using example from issue:

<img width="1016" alt="Screen Shot 2019-08-08 at 11 30 06 AM" src="https://user-images.githubusercontent.com/4806877/62716297-ebfb6200-b9cf-11e9-9ae4-243274262457.png">


Not sure how to test.