### PR TITLE
Removed some unused imports

### DIFF
--- a/examples/user_guide/Gridded_Data.ipynb
+++ b/examples/user_guide/Gridded_Data.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import xarray as xr\n",
     "import hvplot.xarray\n",
     "\n",

--- a/examples/user_guide/NetworkX.ipynb
+++ b/examples/user_guide/NetworkX.ipynb
@@ -15,7 +15,6 @@
    "source": [
     "import hvplot.networkx as hvnx\n",
     "\n",
-    "import numpy as np\n",
     "import networkx as nx\n",
     "import holoviews as hv"
    ]
@@ -590,7 +589,6 @@
     "# Author: Aric Hagberg (hagberg@lanl.gov)\n",
     "# Adapted by Philipp Rudiger <prudiger@anaconda.com>\n",
     "\n",
-    "import matplotlib.pyplot as plt\n",
     "import networkx as nx\n",
     "\n",
     "G = nx.Graph()\n",

--- a/examples/user_guide/Plotting.ipynb
+++ b/examples/user_guide/Plotting.ipynb
@@ -13,7 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import intake\n",
     "import numpy as np\n",
     "import hvplot.pandas\n",
     "import hvplot.dask"

--- a/examples/user_guide/Subplots.ipynb
+++ b/examples/user_guide/Subplots.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import xarray as xr\n",
     "import hvplot.pandas\n",
     "import hvplot.xarray\n",


### PR DESCRIPTION
Removed some unused imports.

Wasn't sure if it's ok to remove the intake import or not in Plotting.ipynb?

-----

Ignore deliberate side effect imports:

```
diff --git a/tox.ini b/tox.ini
index 8ab9e46..25834a4 100644
--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,8 @@ norecursedirs = doc .git dist build _build .ipynb_checkpoints
 #                   .*gallery/bokeh/xarray_gridded\.ipynb$
 #                   .*gallery/.*/xarray_image\.ipynb$
 #                   .*gallery/.*/xarray_quadmesh\.ipynb$
-
+nbsmoke_flakes_to_ignore = .*hvplot\..* imported but unused.*
+
 [flake8]
 include = *.py
 # run_tests.py is generated by conda build, which appears to have a
```


```
(nbsdev) D:\code\pyviz\hvplot>pytest -v --nbsmoke-lint --nbsmoke-lint-debug examples
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.4.1, py-1.8.0, pluggy-0.9.0 -- d:\venvs\nbsdev\scripts\python.exe
cachedir: .pytest_cache
rootdir: D:\code\pyviz\hvplot, inifile: tox.ini
plugins: cov-2.7.1, nbsmoke-0.2.8.post44+gbdfd485
collected 11 items / 22 skipped

examples/homepage.ipynb::D:\code\pyviz\hvplot\examples\homepage.ipynb PASSED                                                                  [  9%]
examples/user_guide/Customization.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Customization.ipynb PASSED                                  [ 18%]
examples/user_guide/Geographic_Data.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Geographic_Data.ipynb PASSED                              [ 27%]
examples/user_guide/Gridded_Data.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Gridded_Data.ipynb FAILED                                    [ 36%]
examples/user_guide/Introduction.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Introduction.ipynb PASSED                                    [ 45%]
examples/user_guide/NetworkX.ipynb::D:\code\pyviz\hvplot\examples\user_guide\NetworkX.ipynb FAILED                                            [ 54%]
examples/user_guide/Plotting.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Plotting.ipynb FAILED                                            [ 63%]
examples/user_guide/Statistical_Plots.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Statistical_Plots.ipynb PASSED                          [ 72%]
examples/user_guide/Streaming.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Streaming.ipynb PASSED                                          [ 81%]
examples/user_guide/Subplots.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Subplots.ipynb FAILED                                            [ 90%]
examples/user_guide/Viewing.ipynb::D:\code\pyviz\hvplot\examples\user_guide\Viewing.ipynb FAILED                                              [100%]

===================================================================== FAILURES =====================================================================
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\hvplot\examples\user_guide\Gridded_Data.ipynb
** line 18 col 0: 'numpy as np' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\hvplot\examples\user_guide\Gridded_Data.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\hvplot\examples\user_guide\Gridded_Data.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\hvplot\examples\user_guide\NetworkX.ipynb
** line 18 col 0: 'numpy as np' imported but unused
** line 443 col 0: 'matplotlib.pyplot as plt' imported but unused
** line 524 col 4: redefinition of unused 'pygraphviz' from line 275
** line 524 col 4: 'pygraphviz' imported but unused
** line 529 col 8: redefinition of unused 'pydot' from line 279
** line 529 col 8: 'pydot' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\hvplot\examples\user_guide\NetworkX.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\hvplot\examples\user_guide\NetworkX.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\hvplot\examples\user_guide\Plotting.ipynb
** line 16 col 0: 'intake' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\hvplot\examples\user_guide\Plotting.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\hvplot\examples\user_guide\Plotting.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\hvplot\examples\user_guide\Subplots.ipynb
** line 18 col 0: 'numpy as np' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\hvplot\examples\user_guide\Subplots.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\hvplot\examples\user_guide\Subplots.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\hvplot\examples\user_guide\Viewing.ipynb
** line 42 col 9: undefined name 'display'
To see python source that was checked by pyflakes: D:\code\pyviz\hvplot\examples\user_guide\Viewing.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\hvplot\examples\user_guide\Viewing.nbsmoke-debug-premagicprocess.py
================================================= 5 failed, 6 passed, 22 skipped in 20.49 seconds ==================================================
```

Haven't decided yet what nbsmoke should do about `display()`. I'd like it to complain by default (requiring display to be explicitly imported), but I'm open to suggestions about that. I didn't look at the graphviz/dot bits of the networkx example.