### PR TITLE
Made hvplot API dynamic by accepting parameter/widget instances

### DIFF
--- a/hvplot/tests/testpanel.py
+++ b/hvplot/tests/testpanel.py
@@ -1,0 +1,69 @@
+"""
+Tests for panel widgets and param objects as arguments
+"""
+from unittest import TestCase, SkipTest
+
+from hvplot.util import process_xarray  # noqa
+
+def look_for_class(panel, classname, items=None):
+    """
+    Descend a panel object and find any instances of the given class
+    """
+    import panel as pn
+
+    if items is None:
+        items = []
+    if isinstance(panel, pn.layout.ListPanel):
+        for p in panel:
+            items = look_for_class(p, classname, items)
+    elif isinstance(panel, classname):
+        items.append(panel)
+    return items
+
+
+class TestPanelObjects(TestCase):
+
+    def setUp(self):
+        try:
+            import panel as pn  # noqa
+            import hvplot.pandas  # noqa
+        except:
+            raise SkipTest('panel not available')
+
+        from bokeh.sampledata.iris import flowers
+        self.flowers = flowers
+        self.cols = list(self.flowers.columns[:-1])
+
+
+    def test_using_explicit_widgets_works(self):
+        import panel as pn
+
+        x = pn.widgets.Select(name='x', value='sepal_length', options=self.cols)
+        y = pn.widgets.Select(name='y', value='sepal_width', options=self.cols)
+        kind = pn.widgets.Select(name='kind', value='scatter', options=['bivariate', 'scatter'])
+        by_species = pn.widgets.Checkbox(name='By species')
+        color = pn.widgets.ColorPicker(value='#ff0000')
+
+        @pn.depends(by_species.param.value, color.param.value)
+        def by_species_fn(by_species, color):
+            return 'species' if by_species else color
+
+        self.flowers.hvplot(x, y=y, kind=kind.param.value, c=color)
+
+    def test_casting_widgets_to_different_classes(self):
+        import panel as pn
+
+        pane = self.flowers.hvplot.scatter(
+            groupby='species', legend='top_right',
+            widgets={'species': pn.widgets.DiscreteSlider})
+
+        assert len(look_for_class(pane, pn.widgets.DiscreteSlider)) == 1
+
+    def test_using_explicit_widgets_with_groupby_raises_error(self):
+        import panel as pn
+
+        x = pn.widgets.Select(name='x', value='sepal_length', options=self.cols)
+        y = pn.widgets.Select(name='y', value='sepal_width', options=self.cols)
+
+        with self.assertRaisesRegex(ValueError, "Groupby is not yet"):
+            self.flowers.hvplot(x, y, groupby='species')

--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -207,3 +207,58 @@ class TestGeoUtil(TestCase):
         crs = proj_to_cartopy('+init=epsg:26911')
 
         assert isinstance(crs, self.ccrs.CRS)
+
+
+class TestDynamicArgs(TestCase):
+
+    def setUp(self):
+        try:
+            import panel as pn  # noqa
+        except:
+            raise SkipTest('panel not available')
+
+    def test_dynamic_and_static(self):
+        import panel as pn
+        from ..util import process_dynamic_args
+
+        x = 'sepal_width'
+        y = pn.widgets.Select(name='y', value='sepal_length', options=['sepal_length', 'petal_length'])
+        kind = pn.widgets.Select(name='kind', value='scatter', options=['bivariate', 'scatter'])
+
+        dynamic, arg_deps, arg_names = process_dynamic_args(x, y, kind)
+        assert 'x' not in dynamic
+        assert 'y' in dynamic
+        assert arg_deps == []
+
+    def test_dynamic_kwds(self):
+        import panel as pn
+        from ..util import process_dynamic_args
+
+        x = 'sepal_length'
+        y = 'sepal_width'
+        kind = 'scatter'
+        color = pn.widgets.ColorPicker(value='#ff0000')
+
+        dynamic, arg_deps, arg_names = process_dynamic_args(x, y, kind, c=color)
+        assert 'x' not in dynamic
+        assert 'c' in dynamic
+        assert arg_deps == []
+
+    def test_fn_kwds(self):
+        import panel as pn
+        from ..util import process_dynamic_args
+
+        x = 'sepal_length'
+        y = 'sepal_width'
+        kind = 'scatter'
+        by_species = pn.widgets.Checkbox(name='By species')
+        color = pn.widgets.ColorPicker(value='#ff0000')
+
+        @pn.depends(by_species.param.value, color.param.value)
+        def by_species_fn(by_species, color):
+            return 'species' if by_species else color
+
+        dynamic, arg_deps, arg_names = process_dynamic_args(x, y, kind, c=by_species_fn)
+        assert dynamic == {}
+        assert arg_names == ['c', 'c']
+        assert len(arg_deps) == 2

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ install_requires = [
 
 _examples_extra = [
     'geoviews >=1.6.0',
+    'panel',
     'geopandas',
     'xarray',
     'networkx',


### PR DESCRIPTION
NEW: Replacing #279 and updating to accept widgets as well as parameters.

This PR makes it possible to build GUIs by passing parameters instances directly into the hvPlot methods. Combined with Panel this makes it very easy to build complex GUIs.


```python 
import panel as pn
import hvplot.pandas

from bokeh.sampledata.iris import flowers

cols = list(flowers.columns[:-1])
x = pn.widgets.Select(name='x', value='sepal_length', options=cols)
y = pn.widgets.Select(name='y', value='sepal_width', options=cols)
kind = pn.widgets.Select(name='kind', value='scatter', options=['bivariate', 'scatter'])
by_species = pn.widgets.Checkbox(name='By species')
color = pn.widgets.ColorPicker(value='#ff0000')

@pn.depends(by_species, color)
def by_species_fn(by_species, color):
    return 'species' if by_species else color

plot = flowers.hvplot(x=x, y=y, kind=kind, c=by_species_fn)

pn.Row(pn.WidgetBox(x, y, kind, color, by_species), plot)
```

![iris_explorer](https://user-images.githubusercontent.com/1550771/62623736-e0516200-b921-11e9-999c-f54945047efa.gif)

This examples demonstrate how both parameters and functions that depend on some parameter(s) can be used to dynamically update a plot. In this case the ``by_species_fn`` returns either the 'species' column or the `ColorPicker` depending on whether the checkbox is ticked, making it simple to specify even complex behaviors.

Currently this re-renders the plot every time a parameter changes. A future exercise can be to optimize this by handling certain parameters internally using DynamicMaps.

- [x] Clean up code
- [ ] Add docs
- [x] Add tests

closes #325 