### PR TITLE
Stop swallowing groupby widgets when passing widgets

### DIFF
--- a/hvplot/tests/testpanel.py
+++ b/hvplot/tests/testpanel.py
@@ -59,11 +59,10 @@ class TestPanelObjects(TestCase):
 
         assert len(look_for_class(pane, pn.widgets.DiscreteSlider)) == 1
 
-    def test_using_explicit_widgets_with_groupby_raises_error(self):
+    def test_using_explicit_widgets_with_groupby_does_not_raise_error(self):
         import panel as pn
 
         x = pn.widgets.Select(name='x', value='sepal_length', options=self.cols)
         y = pn.widgets.Select(name='y', value='sepal_width', options=self.cols)
 
-        with self.assertRaisesRegex(ValueError, "Groupby is not yet"):
-            self.flowers.hvplot(x, y, groupby='species')
+        self.flowers.hvplot(x, y, groupby='species')

--- a/hvplot/tests/testpanel.py
+++ b/hvplot/tests/testpanel.py
@@ -65,4 +65,5 @@ class TestPanelObjects(TestCase):
         x = pn.widgets.Select(name='x', value='sepal_length', options=self.cols)
         y = pn.widgets.Select(name='y', value='sepal_width', options=self.cols)
 
-        self.flowers.hvplot(x, y, groupby='species')
+        pane = self.flowers.hvplot(x, y, groupby='species')
+        assert isinstance(pane, pn.param.ParamFunction)


### PR DESCRIPTION
This is kind of a follow on to the widget work in #331 and #323 this lets the groupby widget that hvplot creates get through even when other widgets options are used. 

```python
import xarray as xr
import hvplot.xarray

import geoviews.tile_sources as gvts
import panel as pn

base_map = pn.widgets.Select(options=list(gvts.tile_sources.keys()), value='EsriImagery')
data = xr.tutorial.load_dataset('air_temperature').air

pn.Column(
    base_map,
    data.hvplot.contour(geo=True, tiles=base_map, widget_type='scrubber', 
                        widget_location='top', widget_layout=pn.Row,
                        levels=10, cmap='reds', line_width=2))
```
![widgets](https://user-images.githubusercontent.com/4806877/67042156-495d0f00-f0f5-11e9-8e8e-08e9262f8d8c.gif)

